### PR TITLE
Fixed tooltip hover issue on iOS - Tooltips would not display on on click

### DIFF
--- a/Data/BuilderNew.js
+++ b/Data/BuilderNew.js
@@ -271,6 +271,7 @@
              var tex = document.createElement("DIV");
              tex.className = "tooltip";
              tex.innerHTML = abilityName;
+             tex.setAttribute('onclick', '');
              var dam = document.createElement("DIV");
              dam.className = "ability_damage";
              dam.innerHTML = abilityDam;
@@ -309,6 +310,7 @@
              var spa = document.createElement("SPAN");
              var tex = document.createElement("DIV");
              tex.className = "tooltip";
+             tex.setAttribute('onclick', '');
              tex.innerHTML = abilityName;
              spa.className = "tooltiptext";
              spa.innerHTML = "<p>" + "<span style=\"font-size=20px; color=rgb(158, 197, 225)\">" + abilityName + "</p>" + "<hr>" + abilityDescr;
@@ -347,6 +349,7 @@
              dam.innerHTML = abilityDam;
 
              tex.className = "tooltip";
+             tex.setAttribute('onclick', '');
              tex.innerHTML = abilityName;
 
              spa.className = "tooltiptext";
@@ -394,6 +397,7 @@
              var spa = document.createElement("SPAN");
              var tex = document.createElement("DIV");
              tex.className = "tooltip";
+             tex.setAttribute('onclick', '');
              tex.innerHTML = abilityName;
              spa.className = "tooltiptext";
              spa.innerHTML = "<p>" + "<span style=\"font-size=20px\">" + abilityName + "</p>" + "<hr>" + abilityDescr;
@@ -840,6 +844,7 @@
              var spa = document.createElement("SPAN");
              var tex = document.createElement("DIV");
              tex.className = "tooltip";
+             tex.setAttribute('onclick', '');
              //tex.innerHTML = modUnlockName;
 
              spa.innerHTML = "<p>" + opUnlockName + "</p>" + tier + "<hr>"
@@ -949,6 +954,7 @@
              var spa = document.createElement("SPAN");
              var tex = document.createElement("DIV");
              tex.className = "tooltip";
+             tex.setAttribute('onclick', '');
              //tex.innerHTML = modUnlockName;
 
              spa.innerHTML = "<p>" + unitNameShort + "</p>" + tier + "<hr>";


### PR DESCRIPTION
Fixed an issue where clicking on abilities, resistances, passives and elite skills would not display the corresponding tooltip on iOS Safari.

Tested on 

* Safari on iOS
* Safari for MacOS Catalina, 
* Firefox on MacOS Catalina
* Chrome on MacOS Catalina
* Firefox on Windows 10
* Chrome on Windows 10
* Edge on Windows 10
